### PR TITLE
DMS-256 rework linked person display

### DIFF
--- a/ubo-cli/src/main/setup/classifications/user_attributes.xml
+++ b/ubo-cli/src/main/setup/classifications/user_attributes.xml
@@ -6,18 +6,25 @@
   <categories>
     <category ID="id_local">
       <label xml:lang="de" text="Lokale ID" />
+      <label xml:lang="x-display" text="false" />
     </category>
     <category ID="id_gnd">
       <label xml:lang="de" text="GND" />
+      <label xml:lang="x-display" text="true" />
+      <label xml:lang="x-uri" text="http://d-nb.info/gnd/" />
     </category>
     <category ID="id_orcid">
       <label xml:lang="de" text="ORCID" />
+      <label xml:lang="x-display" text="true" />
+      <label xml:lang="x-uri" text="http://orcid.org/" />
     </category>
     <category ID="id_scopus">
       <label xml:lang="de" text="SCOPUS" />
+      <label xml:lang="x-display" text="true" />
     </category>
     <category ID="id_researcherid">
       <label xml:lang="de" text="ResearcherID" />
+      <label xml:lang="x-display" text="true" />
     </category>
   </categories>
 </mycoreclass>

--- a/ubo-common/src/main/java/org/mycore/ubo/UBOUserByConnectionResolver.java
+++ b/ubo-common/src/main/java/org/mycore/ubo/UBOUserByConnectionResolver.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.ubo;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.Element;
+import org.jdom2.transform.JDOMSource;
+import org.mycore.user2.MCRUser;
+import org.mycore.user2.MCRUserManager;
+import org.mycore.user2.utils.MCRUserTransformer;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.util.JAXBSource;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Resolves a User by connection id
+ */
+public class UBOUserByConnectionResolver implements URIResolver {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Override
+    public Source resolve(String href, String base) throws TransformerException {
+        String connection_id = href.split(":", 2)[1];
+        final List<MCRUser> users = MCRUserManager.getUsers("id_connection", connection_id).collect(Collectors.toList());
+        if(users.size()!=1){
+            LOGGER.warn("There is a connection ID which has no User in DB {}", connection_id);
+            return new JDOMSource(new Element("null"));
+        }
+        final MCRUser user = users.get(0);
+
+        try {
+            return new JAXBSource(MCRUserTransformer.JAXB_CONTEXT, user.getSafeCopy());
+        } catch (JAXBException e) {
+            throw new TransformerException(e);
+        }
+    }
+
+}

--- a/ubo-common/src/main/resources/META-INF/resources/js/person-popover.js
+++ b/ubo-common/src/main/resources/META-INF/resources/js/person-popover.js
@@ -1,0 +1,35 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+$( document ).ready(function() {
+    $(".personPopover").each(function (i, popoverElement) {
+        let id = popoverElement.getAttribute("id");
+        let contentID = id + "-content";
+        let content$ = $("#" + contentID);
+        content$.detach();
+        content$.removeClass("d-none");
+        popoverElement.setAttribute("title", popoverElement.getAttribute("title") + '<div class="popoverclose btn btn-xs"><i class="fa fa-times"></i></div>');
+        $(popoverElement).popover({
+            content: content$,
+            html: true
+        })
+    });
+
+    $("body").on("click", ".popoverclose", function(e){
+        $(this).parents(".popover").popover("hide");
+    });
+});

--- a/ubo-common/src/main/resources/config/ubo-common/mycore.properties
+++ b/ubo-common/src/main/resources/config/ubo-common/mycore.properties
@@ -266,6 +266,8 @@ MCR.URIResolver.ModuleResolver.cache=org.mycore.ubo.CachingResolver
 UBO.CachingResolver.Capacity=100
 UBO.CachingResolver.MaxAge=86400000
 
+MCR.URIResolver.ModuleResolver.userconnection=org.mycore.ubo.UBOUserByConnectionResolver
+
 # Sorting rules for MCRURIResolver
 MCR.URIResolver.Classification.Sort.ORIGIN=false
 MCR.URIResolver.Classification.Sort.rfc4646=true

--- a/ubo-common/src/main/resources/xsl/html-layout.xsl
+++ b/ubo-common/src/main/resources/xsl/html-layout.xsl
@@ -63,7 +63,7 @@
       <script type="text/javascript">var webApplicationBaseURL = '<xsl:value-of select="$WebApplicationBaseURL" />';</script>
       <script type="text/javascript">var currentLang = '<xsl:value-of select="$CurrentLang" />';</script>
       <script type="text/javascript" src="{$WebApplicationBaseURL}js/session-polling.js"></script>
-
+      <script type="text/javascript" src="{$WebApplicationBaseURL}js/person-popover.js"></script>
       <xsl:copy-of select="node()" />
     </head>
   </xsl:template>

--- a/ubo-common/src/main/resources/xsl/mods-display.xsl
+++ b/ubo-common/src/main/resources/xsl/mods-display.xsl
@@ -28,6 +28,8 @@
   <xsl:param name="UBO.Primo.Search.Link" />
   <xsl:param name="UBO.ISBN.Search.Link" />
 
+  <xsl:param name="MCR.ORCID.LinkURL"/>
+
 
   <xsl:variable name="genres" select="document('classification:metadata:-1:children:ubogenre')/mycoreclass/categories" />
   <xsl:variable name="oa"     select="document('classification:metadata:-1:children:oa')/mycoreclass/categories" />
@@ -362,12 +364,19 @@
             <span class="personalName">
               <xsl:if test="mods:affiliation and check:currentUserIsAdmin()">
                 <xsl:attribute name="title">
-                  <xsl:apply-templates select="mods:affiliation" mode="details" />
+                  <xsl:apply-templates select="mods:affiliation" mode="details"/>
                 </xsl:attribute>
               </xsl:if>
-              <xsl:apply-templates select="." />
-              <xsl:apply-templates select="mods:nameIdentifier[@type='orcid']" />
-              <xsl:apply-templates select="mods:nameIdentifier[not(@type='orcid')]" />
+              <xsl:apply-templates select="."/>
+              <xsl:choose>
+                <xsl:when test="count(mods:nameIdentifier[@type='connection']) &gt;0">
+                  <xsl:apply-templates select="mods:nameIdentifier[@type='connection']"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:apply-templates select="mods:nameIdentifier[@type='orcid']"/>
+                  <xsl:apply-templates select="mods:nameIdentifier[not(@type='orcid')]"/>
+                </xsl:otherwise>
+              </xsl:choose>
               <xsl:if test="position() != last()">
                 <xsl:text>; </xsl:text>
               </xsl:if>
@@ -378,20 +387,64 @@
     </xsl:if>
   </xsl:template>
 
-  <xsl:template match="mods:affiliation" mode="details" >
-    <xsl:value-of select="text()" />
-    <xsl:if test="position() != last()"> / </xsl:if>
+  <xsl:template match="mods:affiliation" mode="details">
+    <xsl:value-of select="text()"/>
+    <xsl:if test="position() != last()">/</xsl:if>
   </xsl:template>
 
-  <xsl:param name="UBO.LSF.Link" />
+  <xsl:param name="UBO.LSF.Link"/>
+
+  <xsl:template match="mods:nameIdentifier[@type='connection']">
+    <xsl:variable name="userXML" select="document(concat('userconnection:', text()))"/>
+    <xsl:variable name="userAttributeClassification"
+                  select="document('classification:metadata:-1:children:user_attributes')"/>
+    <xsl:variable name="popId" select="generate-id()"/>
+    <span class="fas fa-user personPopover ml-1" id="{$popId}" title="{i18n:translate('person.search.information')}">
+    </span>
+    <div id="{$popId}-content" class="d-none">
+      <dl>
+        <xsl:if test="count($userXML/user/attributes/attribute) &gt; 0">
+          <xsl:for-each select="$userXML/user/attributes/attribute">
+            <xsl:variable name="attrName" select="@name"/>
+            <xsl:variable name="classNode" select="$userAttributeClassification/.//category[@ID=$attrName]"/>
+            <xsl:if test="count($classNode)&gt;0 and count($classNode/label[@xml:lang='x-display' and @text='true'])&gt;0">
+              <dt>
+                <xsl:value-of select="$classNode/label[lang($CurrentLang)]/@text"/>
+              </dt>
+              <dd>
+                <xsl:choose>
+                  <xsl:when test="$attrName='id_orcid'">
+                    <!-- special display code for orcid -->
+                    <xsl:variable name="url" select="concat($MCR.ORCID.LinkURL,@value)" />
+                    <a href="{$url}" title="ORCID iD: {@value}">
+                      <xsl:value-of select="@value" />
+                      <img alt="ORCID iD" src="{$WebApplicationBaseURL}images/orcid_icon.svg" class="orcid-icon" />
+                    </a>
+                  </xsl:when>
+                  <xsl:when test="count($classNode/label[@xml:lang='x-uri'])  &gt;0">
+                    <!-- display as link -->
+                    <a href="{$classNode/label[@xml:lang='x-uri']/@text}{@value}" title="{$classNode/label[lang($CurrentLang)]/@text}: {@value}">
+                      <xsl:value-of select="@value" />
+                    </a>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <!-- display as text -->
+                    <xsl:value-of select="@value" />
+                  </xsl:otherwise>
+                </xsl:choose>
+              </dd>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:if>
+      </dl>
+    </div>
+  </xsl:template>
 
   <xsl:template match="mods:nameIdentifier[@type='lsf']">
     <span class="nameIdentifier lsf" title="LSF ID: {.}">
       <a href="{$UBO.LSF.Link}{.}">LSF</a>
     </span>
   </xsl:template>
-
-  <xsl:param name="MCR.ORCID.LinkURL" />
 
   <xsl:template match="mods:nameIdentifier[@type='orcid']">
     <xsl:variable name="url" select="concat($MCR.ORCID.LinkURL,text())" />
@@ -431,10 +484,6 @@
         <xsl:otherwise><xsl:value-of select="i18n:translate('ubo.authorlink.local.text')" /></xsl:otherwise>
       </xsl:choose>
     </span>
-  </xsl:template>
-
-  <xsl:template match="mods:nameIdentifier[@type='connection']">
-    <!-- do not display this as it is meant for internal procedures -->
   </xsl:template>
 
   <xsl:template match="mods:nameIdentifier">


### PR DESCRIPTION
**Display of not linked person are unchanged.**

If the person is linked with mods:nameIdentifier[(at)type='connection'], then all mods:nameIdentifier in the document are ignored by the metadata display code and the user attributes of the connected user is displayed instead.

The classification user_attributes controls with the x-display if the Identifier should be shown on the metadata page and there is also the x-uri attribute which can be combined with the id to build a link to the Service.


There is also special code to display the ORCID Icon, maybe if other Service also require special icon, we can store it in the classification.