### PR TITLE
DMS-301 add css class for JOP service images and fix layout

### DIFF
--- a/ubo-common/src/main/resources/META-INF/resources/scss/_ubo-common.scss
+++ b/ubo-common/src/main/resources/META-INF/resources/scss/_ubo-common.scss
@@ -171,6 +171,13 @@
     content: " ";
   }
 
+  .ubo-jopservice-img {
+    float:none;
+    height: 1rem;
+    vertical-align: baseline;
+    padding-left: 5px;
+  }
+
 // Large devices (desktops) and below: <= 1200px
 @include media-breakpoint-down(lg) {
 // add/overwrite styles for responsive level lg and lower

--- a/ubo-common/src/main/resources/xsl/mods-display.xsl
+++ b/ubo-common/src/main/resources/xsl/mods-display.xsl
@@ -1317,7 +1317,7 @@
     <a href="{$UBO.JOP.URL}?{$parameters}" title="{i18n:translate('ubo.jop')}">
       <xsl:value-of select="text()" />
       <xsl:text> </xsl:text>
-      <img style="float:none" loading="lazy" data-src="https://services.dnb.de/fize-service/gvr/icon?{$parameters}" alt="{i18n:translate('ubo.jop')}" />
+      <img class="ubo-jopservice-img" loading="lazy" data-src="https://services.dnb.de/fize-service/gvr/icon?{$parameters}" alt="{i18n:translate('ubo.jop')}" />
     </a>
   </xsl:template>
 


### PR DESCRIPTION
Die JOP-API liefert neuerdings deutlich größere Icons über die API, die etwas das Layout sprengen:

Links zu Beispielen:
https://bibliographie.uni-jena.de/servlets/DozBibEntryServlet?mode=show&id=fsu_mods_00002460
https://bibliografie.th-koeln.de/servlets/DozBibEntryServlet?mode=show&id=bibthk_mods_00011441

Vorher:
![grafik](https://github.com/MyCoRe-Org/ubo/assets/944083/8e491977-1da2-4288-b1d4-2451fbae871e)


Nachher:
![grafik](https://github.com/MyCoRe-Org/ubo/assets/944083/c595372a-36e9-4711-b2f1-a5ac11e05408)
