### PR TITLE
UBO-315 Made search filter base template configurable by introducing …

### DIFF
--- a/ubo-common/src/main/java/org/mycore/ubo/matcher/MCRUserMatcherLDAP.java
+++ b/ubo-common/src/main/java/org/mycore/ubo/matcher/MCRUserMatcherLDAP.java
@@ -100,6 +100,15 @@ public class MCRUserMatcherLDAP implements MCRUserMatcher {
 
     private String realm;
 
+    /**
+     * The default filter applied to LDAP searches
+     *
+     * TODO: take into consideration the member-status of the (email?) of the LDAP-users
+     * */
+    protected final String SEARCH_FILTER_TEMPLATE = MCRConfiguration2
+        .getString("MCR.user2.LDAP.searchFilter.base")
+        .orElse("(&(objectClass=eduPerson)(|%s))");
+
     public MCRUserMatcherLDAP() {
         loadLDAPMappingConfiguration();
         orcid_resolver = MCRConfiguration2.getString(CONFIG_ORCID_NORMALIZATION_RESOLVER).orElse("");
@@ -492,9 +501,6 @@ public class MCRUserMatcherLDAP implements MCRUserMatcher {
      * @return A LDAP-searchfilter of the form (&(objectClass=eduPerson)(|(%a1=%v1)(%a2=%v2)...(%aN=%vN)))
      */
     private String createLDAPSearchFilter(Multimap<String, String> ldapAttributes, String innerTemplate) {
-        // TODO: take into consideration the member-status of the (email?) of the LDAP-users
-        String searchFilterBaseTemplate = "(&(objectClass=eduPerson)(|%s))";
-
         StringBuilder searchFilterInner = new StringBuilder();
         for (Map.Entry<String, Collection<String>> ldapAttribute : ldapAttributes.asMap().entrySet()) {
             String attributeName = ldapAttribute.getKey();
@@ -521,7 +527,7 @@ public class MCRUserMatcherLDAP implements MCRUserMatcher {
                 searchFilterInner.append(")");
             }
         }
-        return String.format(Locale.ROOT, searchFilterBaseTemplate, searchFilterInner);
+        return String.format(Locale.ROOT, SEARCH_FILTER_TEMPLATE, searchFilterInner);
     }
 
     /**

--- a/ubo-common/src/main/resources/config/ubo-common/mycore.properties
+++ b/ubo-common/src/main/resources/config/ubo-common/mycore.properties
@@ -220,6 +220,9 @@ MCR.user2.LDAP.Mapping.explicit=id_orcid:eduPersonOrcid
 # eduPersonScopedAffiliation may be faculty|staff|employee|student|alum|member|affiliate
 # MCR.user2.LDAP.Mapping.Group.eduPersonScopedAffiliation.staff@uni-duisburg-essen.de=submitter
 
+# The default filter applied to LDAP searches
+MCR.user2.LDAP.searchFilter.base=(&(objectClass=eduPerson)(|%s))
+
 # only author and editor are considered as result in the PersonalList
 UBO.Search.PersonalList.Roles=aut.top,cre.top,tch.top,pht.top,prg.top,edt.top
 UBO.Search.PersonalList.Ids=%MCR.user2.matching.lead_id%,dhsbid


### PR DESCRIPTION
…property MCR.user2.LDAP.searchFilter.base=(&(objectClass=eduPerson)(|%s))

[UBO-315](https://mycore.atlassian.net/browse/UBO-315)

[UBO-315]: https://mycore.atlassian.net/browse/UBO-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ