### PR TITLE
UBO-354 Omit credentials when fetching language classification

### DIFF
--- a/ubo-common/src/main/resources/META-INF/resources/js/language-search.js
+++ b/ubo-common/src/main/resources/META-INF/resources/js/language-search.js
@@ -179,6 +179,7 @@ class LanguageSearchInput {
             const baseURL = window['webApplicationBaseURL'];
             const response = await fetch(baseURL + 'api/v2/classifications/rfc5646', {
                 method: 'GET',
+                credentials: 'omit',
                 headers: {
                     'Accept': 'application/json'
                 }


### PR DESCRIPTION
[UBO-354](https://mycore.atlassian.net/browse/UBO-354)

[UBO-354]: https://mycore.atlassian.net/browse/UBO-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ