### PR TITLE
IM-154 add decimal format on response page

### DIFF
--- a/ubo-common/src/main/resources/xsl/response-facets.xsl
+++ b/ubo-common/src/main/resources/xsl/response-facets.xsl
@@ -15,6 +15,8 @@
 <xsl:param name="RequestURL" />
 <xsl:param name="ServletsBaseURL" />
 
+<xsl:decimal-format name="WesternEurope" decimal-separator="," grouping-separator="."/>
+
 <xsl:variable name="maxFacetValuesDisplayed">5</xsl:variable>
 <xsl:variable name="quotes">"</xsl:variable>
 <xsl:variable name="fq_not">-</xsl:variable>
@@ -193,7 +195,7 @@
       <xsl:attribute name="style">display:none;</xsl:attribute>
     </xsl:if>
     <span class="mycore-facet-count">
-      <xsl:value-of select="text()" />
+      <xsl:value-of select="format-number(text(), '##.###', 'WesternEurope')" />
     </span>
     <xsl:variable name="fq" select="encoder:encode(concat(../@name,':', $quotes, solrUtil:escapeSearchValue(@name), $quotes), 'UTF-8')" />
     <xsl:variable name="facet-human-readable">

--- a/ubo-common/src/main/resources/xsl/response.xsl
+++ b/ubo-common/src/main/resources/xsl/response.xsl
@@ -26,6 +26,8 @@
 <xsl:param name="MCR.ORCID2.OAuth.ClientSecret" select="''" />
 <xsl:param name="MCR.ORCID2.OAuth.Scope" select="''" />
 
+<xsl:decimal-format name="WesternEurope" decimal-separator="," grouping-separator="."/>
+
 <!-- ==================== Trefferliste Metadaten ==================== -->
 
 <xsl:variable name="numFound" select="/response/result[@name='response']/@numFound" />
@@ -60,7 +62,7 @@
   <xsl:text>: </xsl:text>
   <xsl:choose>
     <xsl:when test="$numFound > 1">
-      <xsl:value-of select="$numFound" />
+      <xsl:value-of select="format-number($numFound, '##.###', 'WesternEurope')" />
       <xsl:text> </xsl:text>
       <xsl:value-of select="i18n:translate('result.dozbib.publicationMany')"/>
     </xsl:when>


### PR DESCRIPTION
Die TH Köln wünscht sich besser lesbare Zahlen mit entsprechender Formatierung. Ich hab das z.T. schon umgesetzt, vgl. https://ubo-test.gbv.de/koeln/servlets/solr/select?q=objectType%3A%22mods%22&fl=*&sort=year+desc&rows=10&version=4.5&mask=index.xed aber für die Facetten z.B. kommt das aus dem UBO-Kern, weswegen diese Zahlen noch unformatiert sind. Ist das ein Feature für alle? Spricht was dagegen das im Kern einzubinden?