### PR TITLE
UBO-425 Bypass bug in MCRLanguageResolver (MCR-3491) to allow resolving of language codes with dashes

### DIFF
--- a/ubo-common/src/main/resources/xsl/mods-display.xsl
+++ b/ubo-common/src/main/resources/xsl/mods-display.xsl
@@ -1691,7 +1691,7 @@
   <!-- ========== Sprache eines Eintrages ========== -->
   <xsl:template match="@xml:lang">
     <xsl:text> in </xsl:text>
-    <xsl:value-of select="document(concat('language:',.))/language/label[@xml:lang=$CurrentLang]" />
+    <xsl:value-of select="document(concat('notnull:callJava:org.mycore.common.xml.MCRXMLFunctions:getDisplayName:rfc5646:', .,':', $CurrentLang))" />
   </xsl:template>
 
   <!-- ========== Sprache der Publikation ========== -->


### PR DESCRIPTION
[UBO-425](https://mycore.atlassian.net/browse/UBO-425)

[UBO-425]: https://mycore.atlassian.net/browse/UBO-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ