### PR TITLE
UBO-449 Added order annotionen to servflag migration commands

### DIFF
--- a/ubo-common/src/main/java/org/mycore/ubo/DozBibCommands.java
+++ b/ubo-common/src/main/java/org/mycore/ubo/DozBibCommands.java
@@ -74,7 +74,7 @@ public class DozBibCommands {
     private static XPathExpression<Element> SERVFLAG_XPATH = XPATH_FACTORY.compile("//servflag[@type='status']",
         Filters.element(), null, MODS_NAMESPACE);
 
-    @MCRCommand(syntax = "migrate status to state classification of {0}", help = "Migrates the status servflag to a servstate")
+    @MCRCommand(syntax = "migrate status to state classification of {0}", help = "Migrates the status servflag to a servstate", order = 1)
     public static void migrateState(String objectId) {
         if (!MCRObjectID.isValid(objectId)) {
             LOGGER.error("'{}' is not a valid MCRObjectID", objectId);
@@ -115,7 +115,7 @@ public class DozBibCommands {
         }
     }
 
-    @MCRCommand(syntax = "migrate status to state classification", help = "Migrates the status servflag to a servstate for all objects")
+    @MCRCommand(syntax = "migrate status to state classification", help = "Migrates the status servflag to a servstate for all objects", order = 2)
     public static List<String> migrateState() {
         List<String> commandList = new ArrayList<>();
         List<String> mcrids = MCRXMLMetadataManager.getInstance().listIDsOfType("mods");


### PR DESCRIPTION
[UBO-449](https://mycore.atlassian.net/browse/UBO-449)

[UBO-449]: https://mycore.atlassian.net/browse/UBO-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ