### PR TITLE
UBO-460 Made solr field type ubo_id sortable to be useable when Solr is in cloud mode. To make this work, fields of that type must be stored.

### DIFF
--- a/ubo-common/src/main/resources/config/ubo-common/solr/main/solr-schema.json
+++ b/ubo-common/src/main/resources/config/ubo-common/solr/main/solr-schema.json
@@ -2,7 +2,7 @@
   {
     "add-field-type": {
       "name": "ubo_id",
-      "class": "solr.TextField",
+      "class": "solr.SortableTextField",
       "analyzer": {
         "tokenizer": {
           "class": "solr.KeywordTokenizerFactory"
@@ -245,7 +245,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -254,7 +254,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -263,7 +263,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -272,7 +272,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -299,7 +299,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -416,7 +416,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -480,7 +480,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -543,7 +543,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -597,7 +597,7 @@
       "type": "ubo_id",
       "multiValued": false,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {
@@ -662,7 +662,7 @@
       "type": "ubo_id",
       "multiValued": true,
       "indexed": true,
-      "stored": false
+      "stored": true
     }
   },
   {


### PR DESCRIPTION
[UBO-460](https://mycore.atlassian.net/browse/UBO-460)

[UBO-460]: https://mycore.atlassian.net/browse/UBO-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ