### PR TITLE
UBO-484 Add x-color-chart labels to oa classification

### DIFF
--- a/ubo-cli/src/main/setup/classifications/oa.xml
+++ b/ubo-cli/src/main/setup/classifications/oa.xml
@@ -4,32 +4,38 @@
   <label xml:lang="en" text="Open Access" description="Open Access Publikationsweg" />
   <label xml:lang="de" text="Open Access" description="Open Access Road" />
   <label xml:lang="x-color" text="#5858FA" />
+  <label xml:lang="x-color-chart" text="#5858FA" />
   <categories>
     <category ID="closed">
       <label xml:lang="de" text="Closed access" />
       <label xml:lang="en" text="Closed access" />
       <label xml:lang="x-color" text="#5fa8e8" />
+      <label xml:lang="x-color-chart" text="#5fa8e8" />
     </category>
     <category ID="oa">
       <label xml:lang="de" text="Open Access" />
       <label xml:lang="en" text="Open Access" />
       <label xml:lang="x-color" text="#C8FE2E" />
+      <label xml:lang="x-color-chart" text="#C8FE2E" />
       <category ID="green">
         <!-- Publikation ist in einer lizenzpflichtigen Zeitschrift erschienen, eine (evtl. andere) Version des Artikels wurde auf DuEPublico publiziert (Zweitveröffentlichung). -->
         <label xml:lang="de" text="OA Grün" />
         <label xml:lang="en" text="OA Green" />
         <label xml:lang="x-color" text="#00FF00" />
+        <label xml:lang="x-color-chart" text="#00FF00" />
       </category>
       <category ID="gold">
         <!-- OA Erstveröffentlichung -->
         <label xml:lang="de" text="OA Gold" />
         <label xml:lang="en" text="OA Gold" />
         <label xml:lang="x-color" text="#FFFF00" />
+        <label xml:lang="x-color-chart" text="#FFFF00" />
         <category ID="diamond">
           <!-- OA Erstveröffentlichung ohne APCs -->
           <label xml:lang="de" text="OA Diamond" />
           <label xml:lang="en" text="OA Diamond" />
           <label xml:lang="x-color" text="#CECECE" />
+          <label xml:lang="x-color-chart" text="#CECECE" />
         </category>
       </category>
       <category ID="hybrid">
@@ -37,18 +43,21 @@
         <label xml:lang="de" text="OA Hybrid" />
         <label xml:lang="en" text="OA Hybrid" />
         <label xml:lang="x-color" text="#FF8000" />
+        <label xml:lang="x-color-chart" text="#FF8000" />
       </category>
       <category ID="bronze">
         <!-- Beim Verlag frei zugänglich, aber nicht unter einer OA Lizenz  -->
         <label xml:lang="de" text="OA Bronze" />
         <label xml:lang="en" text="OA Bronze" />
         <label xml:lang="x-color" text="#BF8970" />
+        <label xml:lang="x-color-chart" text="#BF8970" />
       </category>
       <category ID="embargo">
         <!-- Publikation ist in einer lizenzpflichtigen Zeitschrift erschienen und nach nun bereits abgelaufener Embargofrist für alle frei zugänglich. -->
         <label xml:lang="de" text="OA Embargo" />
         <label xml:lang="en" text="OA Embargo" />
         <label xml:lang="x-color" text="#868A08" />
+        <label xml:lang="x-color-chart" text="#868A08" />
       </category>
     </category>
   </categories>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/UBO-484)

## Summary

- `bar-stacked-oa-chart.xsl` (introduced in UBO-475 / ECharts migration) reads category colors from `label[@xml:lang='x-color-chart']/@text`, but `oa.xml` only defined `x-color` labels — the stacked OA bar chart therefore rendered without the configured category colors.
- Adds a parallel `x-color-chart` label next to every existing `x-color` label in `ubo-cli/src/main/setup/classifications/oa.xml`, mirroring the hex value. No color values are changed.

## Test plan

- [ ] `mvn clean install` passes
- [ ] Reimport the `oa` classification (`update classification from uri ...`) on a test instance
- [ ] Open `/statistics.xml`, confirm the stacked OA bar chart now uses the OA category colors instead of falling back to defaults